### PR TITLE
Add option to remove unknown ipsets

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -196,4 +196,10 @@ class firewalld (
     Service['firewalld'] -> Firewalld_direct_rule <||> ~> Exec['firewalld::reload']
     Service['firewalld'] -> Firewalld_direct_passthrough <||> ~> Exec['firewalld::reload']
 
+    if $purge_unknown_ipsets {
+      Firewalld_ipset <||>
+      ~> resources { 'firewalld_ipset':
+        purge => true,
+      }
+    }
 }

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -33,6 +33,7 @@ describe 'firewalld' do
         :purge_direct_rules => true,
         :purge_direct_chains => true,
         :purge_direct_passthroughs => true,
+        :purge_unknown_ipsets => true
       }
     end
 
@@ -47,6 +48,12 @@ describe 'firewalld' do
     it do
       should contain_firewalld_direct_purge('chain')
     end
+
+    it do
+      should contain_resources('firewalld_ipset')
+        .with_purge(true)
+    end
+
   end
 
   context 'with parameter ports' do


### PR DESCRIPTION
This option is useful if you want to control ipsets only with puppet.