### PR TITLE
Do not check if ipset exists again

### DIFF
--- a/lib/puppet/provider/firewalld_ipset/firewall_cmd.rb
+++ b/lib/puppet/provider/firewalld_ipset/firewall_cmd.rb
@@ -39,7 +39,7 @@ Puppet::Type.type(:firewalld_ipset).provide(
   end
 
   def exists?
-    execute_firewall_cmd(['--get-ipsets'], nil).split(" ").include?(@resource[:name])
+    @property_hash[:ensure] == :present
   end
 
   def create

--- a/spec/unit/puppet/type/firewalld_ipset_spec.rb
+++ b/spec/unit/puppet/type/firewalld_ipset_spec.rb
@@ -43,16 +43,6 @@ describe Puppet::Type.type(:firewalld_ipset) do
       resource.provider
     }
 
-    it "should check if it exists" do
-      provider.expects(:execute_firewall_cmd).with(['--get-ipsets'], nil).returns("blacklist whitelist")
-      expect(provider.exists?).to be_truthy
-    end
-
-    it "should check if it doesnt exist" do
-      provider.expects(:execute_firewall_cmd).with(['--get-ipsets'], nil).returns("blacklist greenlist")
-      expect(provider.exists?).to be_falsey
-    end
-
     it "should create" do
       provider.expects(:execute_firewall_cmd).with(['--new-ipset=whitelist', '--type=hash:ip'], nil)
       provider.expects(:execute_firewall_cmd).with(['--ipset=whitelist', '--add-entry=192.168.2.2'], nil)


### PR DESCRIPTION
If ipset is created with `instances` and `prefetch`, there is no need to
verify if the set exists using firewalld-cmd