### PR TITLE
Verify if firewalld is online before self.execute_firewall_cmd

### DIFF
--- a/spec/unit/puppet/provider/firewalld_ipset_spec.rb
+++ b/spec/unit/puppet/provider/firewalld_ipset_spec.rb
@@ -15,7 +15,7 @@ describe provider_class do
   let(:provider) { resource.provider }
   before :each do
     provider.class.stubs(:execute_firewall_cmd).with(['--get-ipsets'], nil).returns('white black')
-    provider.class.stubs(:execute_firewall_cmd).with(['--state'], nil, false, false).returns(Object.any_instance.stubs(exitstatus: 0))
+    provider.class.stubs(:execute_firewall_cmd).with(['--state'], nil, false, false, false).returns(Object.any_instance.stubs(exitstatus: 0))
     provider.class.stubs(:execute_firewall_cmd).with(['--info-ipset=white'], nil).returns('white
   type: hash:ip
   options: maxelem=200 family=inet6


### PR DESCRIPTION
self.instances method on the provider class did not verify if firewalld had a
correct state before issuing `firewall-cmd` commands.
This was a problem as we were trying to collect ipset informations
without checking if firewalld was ready.

So we move the `available?` implementation to the class method to be
able to verify the current firewalld state.